### PR TITLE
Build with Manifold CLI rather than Heroku env vars

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,7 +4,7 @@
   "scripts": {},
   "env": {
     "MANIFOLD_API_TOKEN": {},
-    "MANIFOLD_USER_ID": {}
+    "MANIFOLD_PROJECT": {}
   },
   "formation": {},
   "addons": [],

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "react-scripts build",
+    "build": "npx @manifoldco/cli run -t manifold -p $MANIFOLD_PROJECT -- react-scripts build",
     "dev": "manifold run -- react-scripts start",
     "eject": "react-scripts eject",
     "start": "NODE_ENV=production npx serve -l \"tcp://0.0.0.0:$PORT\" -s build",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,13 +23,19 @@ const Container = styled.div`
   grid-template-rows: min-content auto;
 `;
 
+const env =
+  process.env.MANIFOLD_PROJECT &&
+  process.env.MANIFOLD_PROJECT.indexOf("stage") !== -1
+    ? "stage"
+    : undefined;
+
 class App extends Component {
   render() {
     return (
       <div className="App">
         <ThemeProvider theme={theme}>
           <Router>
-            <manifold-connection env="stage">
+            <manifold-connection env={env}>
               <Container>
                 <Navbar />
                 <Sidebar />


### PR DESCRIPTION
Before the build wasn’t using the Manifold Dashboard, but those values could get out of sync. This lets us use the Manifold Dashboard projects for everything (but you can now switch the project in Heroku from staging to prod with an env var there).

What this means for local dev: nothing. It was already using the manifold CLI
What this means for the staging URL: everything. Now we can set the project with hosting env vars, and update the values in the projects and have it work everywhere.